### PR TITLE
Allow to set a custom database connection in config file

### DIFF
--- a/publishes/config/vouchers.php
+++ b/publishes/config/vouchers.php
@@ -59,4 +59,6 @@ return [
         'redeemers' => 'redeemers',
         'vouchers'  => 'vouchers',
     ],
+
+    'db_connection' => env('FREBS_VOUCHERS_DB_CONNECTION'),
 ];

--- a/src/Models/Voucher.php
+++ b/src/Models/Voucher.php
@@ -72,6 +72,11 @@ class Voucher extends Model
     {
         $this->table = Config::table('vouchers');
 
+        if (! isset($this->connection)) {
+            $this->setConnection(config('vouchers.db_connection'));
+        }
+
+
         parent::__construct($attributes);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,8 @@ class TestCase extends BaseTestCase
     {
         parent::setUp();
 
+        config()->set('vouchers.db_connection', 'testing');
+
         $this->loadLaravelMigrations();
         $this->artisan('migrate', ['--database' => 'testing']);
         $this->loadMigrationsFrom(__DIR__ . '/database/migrations');

--- a/tests/VoucherDbConnectionTest.php
+++ b/tests/VoucherDbConnectionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FrittenKeeZ\Vouchers\Tests;
+
+use FrittenKeeZ\Vouchers\Models\Voucher;
+
+/**
+ * @internal
+ */
+class VoucherDbConnectionTest extends TestCase
+{
+    /**
+     * Test if the model can use the database connection defined in the config.
+     *
+     * @return void
+     */
+    public function testUsesConnectionFromConfig() : void
+    {
+        $voucher = new Voucher();
+        $this->assertEquals($voucher->getConnectionName(), config('vouchers.db_connection'));
+        $this->assertNotNull($voucher->getConnectionName());
+    }
+
+    /**
+     * Test if the model can use the default database connection if no connection is defined in the config.
+     * @return void
+     */
+    public function testUsesDefaultConnectionIfNotSet() : void
+    {
+        config()->set('vouchers.db_connection', null);
+
+        $voucher = new Voucher();
+        $this->assertInstanceOf('Illuminate\Database\SQLiteConnection', $voucher->getConnection());
+        $this->assertNull(config('vouchers.db_connection'));
+    }
+}


### PR DESCRIPTION
Hello!

This PR add the possibility to set a custom database connection in config. This is very useful when you want to store the data in another database or to "force" relationships between two different databases connections (which is my case).

It's a pretty simple addition, but very useful.

